### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/957/421168957.geojson
+++ b/data/421/168/957/421168957.geojson
@@ -577,6 +577,9 @@
     },
     "wof:country":"CI",
     "wof:created":1459008788,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f08aabdb3aa15e4dac964b770df7cb20",
     "wof:hierarchy":[
         {
@@ -587,7 +590,7 @@
         }
     ],
     "wof:id":421168957,
-    "wof:lastmodified":1566643561,
+    "wof:lastmodified":1582313796,
     "wof:name":"Yamoussoukro",
     "wof:parent_id":1108806119,
     "wof:placetype":"locality",

--- a/data/421/188/355/421188355.geojson
+++ b/data/421/188/355/421188355.geojson
@@ -186,6 +186,9 @@
     },
     "wof:country":"CI",
     "wof:created":1459009543,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0643785f60d5d900433e53c8c182e64e",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":421188355,
-    "wof:lastmodified":1566643565,
+    "wof:lastmodified":1582313796,
     "wof:name":"San Pedro",
     "wof:parent_id":85669889,
     "wof:placetype":"county",

--- a/data/421/199/985/421199985.geojson
+++ b/data/421/199/985/421199985.geojson
@@ -555,6 +555,9 @@
     },
     "wof:country":"CI",
     "wof:created":1459010007,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"901d9b9c8b0864a22addc8acc93d9a75",
     "wof:hierarchy":[
         {
@@ -565,7 +568,7 @@
         }
     ],
     "wof:id":421199985,
-    "wof:lastmodified":1566643567,
+    "wof:lastmodified":1582313797,
     "wof:name":"Abidjan",
     "wof:parent_id":1108806115,
     "wof:placetype":"locality",

--- a/data/856/324/49/85632449.geojson
+++ b/data/856/324/49/85632449.geojson
@@ -1085,6 +1085,11 @@
     },
     "wof:country":"CI",
     "wof:country_alpha3":"CIV",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"16d91018ec198c2d3c3399ff19d89731",
     "wof:hierarchy":[
         {
@@ -1099,7 +1104,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642854,
+    "wof:lastmodified":1582313784,
     "wof:name":"Ivory Coast",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/698/55/85669855.geojson
+++ b/data/856/698/55/85669855.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Savanes District"
     },
     "wof:country":"CI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d7b8359537afdaa6e974c499a684123",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642860,
+    "wof:lastmodified":1582313786,
     "wof:name":"Savanes",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/59/85669859.geojson
+++ b/data/856/698/59/85669859.geojson
@@ -220,6 +220,9 @@
         "wk:page":"Dengu\u00e9l\u00e9 Region"
     },
     "wof:country":"CI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8d0e4ab6e89af09d29d4102104950c4",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642858,
+    "wof:lastmodified":1582313785,
     "wof:name":"Denguele",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/89/85669889.geojson
+++ b/data/856/698/89/85669889.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Bas-Sassandra Region"
     },
     "wof:country":"CI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af678cbd2679c5d78d2e3e864d77fa38",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642859,
+    "wof:lastmodified":1582313786,
     "wof:name":"Bas-Sassandra",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/95/85669895.geojson
+++ b/data/856/698/95/85669895.geojson
@@ -197,6 +197,9 @@
         "wk:page":"Zanzan District"
     },
     "wof:country":"CI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e9776bf3085fdb4153ecf7db605645a",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642858,
+    "wof:lastmodified":1582313785,
     "wof:name":"Zanzan",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/99/85669899.geojson
+++ b/data/856/698/99/85669899.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Vall\u00e9e du Bandama District"
     },
     "wof:country":"CI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46b7fbdf228e1150a4dc87b72c9a9615",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566642860,
+    "wof:lastmodified":1582313786,
     "wof:name":"Valle Du Bandama",
     "wof:parent_id":85632449,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.