### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/199/985/421199985.geojson
+++ b/data/421/199/985/421199985.geojson
@@ -578,6 +578,7 @@
     "wof:concordances":{
         "gn:id":2293538,
         "gp:id":1339615,
+        "ne:id":1159151439,
         "qs_pg:id":569122,
         "wd:id":"Q1515",
         "wk:page":"Abidjan"
@@ -597,7 +598,8 @@
         }
     ],
     "wof:id":421199985,
-    "wof:lastmodified":1607390897,
+    "wof:lastmodified":1608688186,
+    "wof:megacity":1,
     "wof:name":"Abidjan",
     "wof:parent_id":1108806115,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary