### PR TITLE
ci concordances, placetype local, and more

### DIFF
--- a/data/110/878/497/7/1108784977.geojson
+++ b/data/110/878/497/7/1108784977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.503641,
-    "geom:area_square_m":6201285073.920424,
+    "geom:area_square_m":6201284782.674588,
     "geom:bbox":"-6.502922,4.850437,-5.381298,5.629636",
     "geom:latitude":5.268581,
     "geom:longitude":-5.972031,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.BA.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833933,
-    "wof:geomhash":"66487168856f10835c128223ec71c57e",
+    "wof:geomhash":"87ff920077e1a24af83369eb6c402911",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108784977,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886485,
     "wof:name":"Gbokle",
     "wof:parent_id":85669889,
     "wof:placetype":"county",

--- a/data/110/878/498/1/1108784981.geojson
+++ b/data/110/878/498/1/1108784981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.795483,
-    "geom:area_square_m":9784907515.778873,
+    "geom:area_square_m":9784906988.212561,
     "geom:bbox":"-7.208542,5.263476,-5.957904,6.557625",
     "geom:latitude":5.853076,
     "geom:longitude":-6.669269,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"CI.BA.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833934,
-    "wof:geomhash":"5f0b9afa0c2ff2aba8b608e7aa53f1e0",
+    "wof:geomhash":"a216fc083acafe2a38a502a652700e38",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108784981,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886487,
     "wof:name":"Nawa",
     "wof:parent_id":85669889,
     "wof:placetype":"county",

--- a/data/110/878/498/3/1108784983.geojson
+++ b/data/110/878/498/3/1108784983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.568372,
-    "geom:area_square_m":6979680770.770583,
+    "geom:area_square_m":6979680586.354802,
     "geom:bbox":"-3.800895,5.890598,-3.080799,7.355218",
     "geom:latitude":6.715146,
     "geom:longitude":-3.425562,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.CM.ID"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833936,
-    "wof:geomhash":"3708f13efa7c1a64e7b222f89da2b7d3",
+    "wof:geomhash":"e144042618423a89fbc0e82b2e9bbbe5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108784983,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Indenie-Dj",
     "wof:parent_id":85669921,
     "wof:placetype":"county",

--- a/data/110/878/498/5/1108784985.geojson
+++ b/data/110/878/498/5/1108784985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.574012,
-    "geom:area_square_m":7065143342.501904,
+    "geom:area_square_m":7065143602.54703,
     "geom:bbox":"-3.85233,5.091188,-2.723532,6.251522",
     "geom:latitude":5.489755,
     "geom:longitude":-3.17842,
@@ -198,9 +198,10 @@
         "hasc:id":"CI.CM.SC",
         "wd:id":"Q842495"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833937,
-    "wof:geomhash":"b094429d6aeb6f9d2b21c77ae44eebe4",
+    "wof:geomhash":"bc43c40f4080b9fec5f1651d5cc64e4b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1108784985,
-    "wof:lastmodified":1690866718,
+    "wof:lastmodified":1695886342,
     "wof:name":"Sud-Comoe",
     "wof:parent_id":85669927,
     "wof:placetype":"county",

--- a/data/110/878/498/7/1108784987.geojson
+++ b/data/110/878/498/7/1108784987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.550388,
-    "geom:area_square_m":6700150441.715294,
+    "geom:area_square_m":6700150441.715251,
     "geom:bbox":"-8.1638145,9.70876504241,-6.5867442596,10.46204",
     "geom:latitude":10.100669,
     "geom:longitude":-7.407092,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.DE.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833939,
-    "wof:geomhash":"d8b16e326d1a3fa1f1953982dff498d5",
+    "wof:geomhash":"ff633255baec91ffc123b7afb9dd9d35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108784987,
-    "wof:lastmodified":1566643365,
+    "wof:lastmodified":1695886341,
     "wof:name":"Folon",
     "wof:parent_id":85669859,
     "wof:placetype":"county",

--- a/data/110/878/498/9/1108784989.geojson
+++ b/data/110/878/498/9/1108784989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.169387,
-    "geom:area_square_m":14264384966.472738,
+    "geom:area_square_m":14264383760.67263,
     "geom:bbox":"-8.145303,8.51233,-6.738624,9.998875",
     "geom:latitude":9.423148,
     "geom:longitude":-7.379509,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"CI.DE.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833940,
-    "wof:geomhash":"fad8fb2c751ec5d5043766810eba5fd4",
+    "wof:geomhash":"031846c24349f2ff70d5838d51fa3cbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108784989,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Kabadougou",
     "wof:parent_id":85669859,
     "wof:placetype":"county",

--- a/data/110/878/499/1/1108784991.geojson
+++ b/data/110/878/499/1/1108784991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17471,
-    "geom:area_square_m":2150682559.752319,
+    "geom:area_square_m":2150682559.75234,
     "geom:bbox":"-4.45655303934,5.21850385961,-3.72026855823,5.60399687891",
     "geom:latitude":5.41496,
     "geom:longitude":-4.075835,
@@ -395,9 +395,10 @@
     "wof:concordances":{
         "hasc:id":"CI.AB.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833941,
-    "wof:geomhash":"158848a5a0a15b95060e5e61279d8731",
+    "wof:geomhash":"d4f87e93a4489224da0460407a92eea0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -407,7 +408,7 @@
         }
     ],
     "wof:id":1108784991,
-    "wof:lastmodified":1566643363,
+    "wof:lastmodified":1695886341,
     "wof:name":"Abidjan",
     "wof:parent_id":85669909,
     "wof:placetype":"county",

--- a/data/110/878/499/3/1108784993.geojson
+++ b/data/110/878/499/3/1108784993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169408,
-    "geom:area_square_m":2079781302.129818,
+    "geom:area_square_m":2079781302.129819,
     "geom:bbox":"-5.53114934606,6.55267758602,-4.958782179,7.07975937604",
     "geom:latitude":6.855955,
     "geom:longitude":-5.268561,
@@ -425,9 +425,10 @@
     "wof:concordances":{
         "hasc:id":"CI.YM.YM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833942,
-    "wof:geomhash":"fbd91cde9b22990946827c0f2e6ea58b",
+    "wof:geomhash":"35a3c13dfc06bddf47e2044744213388",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -437,7 +438,7 @@
         }
     ],
     "wof:id":1108784993,
-    "wof:lastmodified":1566643364,
+    "wof:lastmodified":1695886341,
     "wof:name":"Yamoussoukro",
     "wof:parent_id":85669923,
     "wof:placetype":"county",

--- a/data/110/878/499/5/1108784995.geojson
+++ b/data/110/878/499/5/1108784995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.564268,
-    "geom:area_square_m":6936218655.328777,
+    "geom:area_square_m":6936218415.475396,
     "geom:bbox":"-6.416361,5.653847,-5.202817,6.649997",
     "geom:latitude":6.216081,
     "geom:longitude":-5.8782,
@@ -216,9 +216,10 @@
         "hasc:id":"CI.GD.GH",
         "wd:id":"Q818774"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833943,
-    "wof:geomhash":"a1d2c608cf175de062e9aebaed33cf60",
+    "wof:geomhash":"646f71d1ea5eb9895590dc39dc09180e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":1108784995,
-    "wof:lastmodified":1690866718,
+    "wof:lastmodified":1695886341,
     "wof:name":"Goh",
     "wof:parent_id":85669879,
     "wof:placetype":"county",

--- a/data/110/878/499/9/1108784999.geojson
+++ b/data/110/878/499/9/1108784999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.716436,
-    "geom:area_square_m":8814095625.968679,
+    "geom:area_square_m":8814095369.387367,
     "geom:bbox":"-6.030142,5.161333,-4.93715,6.269322",
     "geom:latitude":5.757319,
     "geom:longitude":-5.403991,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.GD.LD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833944,
-    "wof:geomhash":"1a414fdd8b073113a0a27f9c06888028",
+    "wof:geomhash":"cee686c74d3cf648faee02624871d257",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108784999,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Loh-Djibou",
     "wof:parent_id":85669885,
     "wof:placetype":"county",

--- a/data/110/878/500/1/1108785001.geojson
+++ b/data/110/878/500/1/1108785001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556635,
-    "geom:area_square_m":6832648371.437746,
+    "geom:area_square_m":6832648249.632317,
     "geom:bbox":"-5.676235,6.236186,-4.646762,7.60748",
     "geom:latitude":6.917593,
     "geom:longitude":-5.034337,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LA.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833945,
-    "wof:geomhash":"5b31f44f8a0e3212f1ee8c3e9c8f6fe5",
+    "wof:geomhash":"d1f230723f45e2aa6081a4d75a89ecb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785001,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886485,
     "wof:name":"Belier",
     "wof:parent_id":85669923,
     "wof:placetype":"county",

--- a/data/110/878/500/3/1108785003.geojson
+++ b/data/110/878/500/3/1108785003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.726537,
-    "geom:area_square_m":8907565448.900499,
+    "geom:area_square_m":8907564757.632549,
     "geom:bbox":"-4.658104,6.950371,-3.496186,8.046169",
     "geom:latitude":7.46432,
     "geom:longitude":-4.060115,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LA.IF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833946,
-    "wof:geomhash":"c81bde63922783ab312771626b12b3de",
+    "wof:geomhash":"2bd67acbf3976d7ff3729c744c463807",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785003,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886486,
     "wof:name":"Iffou",
     "wof:parent_id":85669907,
     "wof:placetype":"county",

--- a/data/110/878/500/5/1108785005.geojson
+++ b/data/110/878/500/5/1108785005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.455263,
-    "geom:area_square_m":5592042568.025767,
+    "geom:area_square_m":5592042464.548306,
     "geom:bbox":"-4.790231,6.188029,-3.736659,7.001096",
     "geom:latitude":6.6033,
     "geom:longitude":-4.238428,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LA.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833947,
-    "wof:geomhash":"ad1e1788ced90e5d5727df1894213f40",
+    "wof:geomhash":"07a420b826c94e03f9d9434e884a58c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785005,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Moronou",
     "wof:parent_id":85669907,
     "wof:placetype":"county",

--- a/data/110/878/500/7/1108785007.geojson
+++ b/data/110/878/500/7/1108785007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394267,
-    "geom:area_square_m":4839088283.086014,
+    "geom:area_square_m":4839088319.577576,
     "geom:bbox":"-4.976489,6.561061,-4.046789,7.481492",
     "geom:latitude":6.97355,
     "geom:longitude":-4.560559,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LA.NZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833948,
-    "wof:geomhash":"e3399289c730b1e9debe2de881ec1c3f",
+    "wof:geomhash":"37e84343c55f06d9dd1f129579fc4a67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108785007,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886489,
     "wof:name":"N'Zi",
     "wof:parent_id":85669907,
     "wof:placetype":"county",

--- a/data/110/878/500/9/1108785009.geojson
+++ b/data/110/878/500/9/1108785009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.66315,
-    "geom:area_square_m":8155960166.779982,
+    "geom:area_square_m":8155960200.071614,
     "geom:bbox":"-5.241422,5.533397,-3.933449,6.373252",
     "geom:latitude":5.936033,
     "geom:longitude":-4.518266,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LN.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833949,
-    "wof:geomhash":"65a76bb58ae8ed43bc0f63636c85606f",
+    "wof:geomhash":"193e127634de56aca9f986d65eaff7ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785009,
-    "wof:lastmodified":1627522001,
+    "wof:lastmodified":1695886484,
     "wof:name":"Agneby-Tia",
     "wof:parent_id":85669903,
     "wof:placetype":"county",

--- a/data/110/878/501/1/1108785011.geojson
+++ b/data/110/878/501/1/1108785011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362193,
-    "geom:area_square_m":4458984882.711404,
+    "geom:area_square_m":4458985204.700099,
     "geom:bbox":"-5.50802,5.091222,-4.215403,5.817817",
     "geom:latitude":5.359735,
     "geom:longitude":-4.77595,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LN.GP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833950,
-    "wof:geomhash":"7f3e4b30f3e68ba07c453dff580e7736",
+    "wof:geomhash":"c1ac3ffc485f3c16cad9fb383b53cf08",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785011,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886486,
     "wof:name":"Grands Pon",
     "wof:parent_id":85669909,
     "wof:placetype":"county",

--- a/data/110/878/501/3/1108785013.geojson
+++ b/data/110/878/501/3/1108785013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.656774,
-    "geom:area_square_m":8076678171.848376,
+    "geom:area_square_m":8076678481.521189,
     "geom:bbox":"-4.161709,5.230709,-3.301239,6.643886",
     "geom:latitude":5.989344,
     "geom:longitude":-3.743198,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"CI.LN.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833951,
-    "wof:geomhash":"c88c65bb085ac61c450caca0ece57558",
+    "wof:geomhash":"b9380f6e2793eeb1091250df17656ce6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108785013,
-    "wof:lastmodified":1627522003,
+    "wof:lastmodified":1695886489,
     "wof:name":"Me",
     "wof:parent_id":85669903,
     "wof:placetype":"county",

--- a/data/110/878/501/7/1108785017.geojson
+++ b/data/110/878/501/7/1108785017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.919699,
-    "geom:area_square_m":11302645378.129677,
+    "geom:area_square_m":11302643283.250853,
     "geom:bbox":"-8.602059,5.618337,-7.082454,6.976947",
     "geom:latitude":6.335305,
     "geom:longitude":-7.686781,
@@ -99,9 +99,10 @@
         "hasc:id":"CI.MN.CV",
         "wd:id":"Q20641894"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833952,
-    "wof:geomhash":"334cbd2c098eea912e856f014aeba493",
+    "wof:geomhash":"3fb4203876c39e49756d030d3af01116",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108785017,
-    "wof:lastmodified":1690866719,
+    "wof:lastmodified":1695886619,
     "wof:name":"Cavally",
     "wof:parent_id":85669915,
     "wof:placetype":"county",

--- a/data/110/878/501/9/1108785019.geojson
+++ b/data/110/878/501/9/1108785019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.587052,
-    "geom:area_square_m":7204517450.466761,
+    "geom:area_square_m":7204517743.584809,
     "geom:bbox":"-7.991462,6.350568,-6.973582,7.725452",
     "geom:latitude":7.018517,
     "geom:longitude":-7.31642,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.MN.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833953,
-    "wof:geomhash":"a50c0b4c486b72e2bbc0370de94746a6",
+    "wof:geomhash":"5d8ac80bdacaf2ca12b028b225b04b76",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785019,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886486,
     "wof:name":"Guemon",
     "wof:parent_id":85669915,
     "wof:placetype":"county",

--- a/data/110/878/502/1/1108785021.geojson
+++ b/data/110/878/502/1/1108785021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.000601,
-    "geom:area_square_m":12267299901.746342,
+    "geom:area_square_m":12267299901.746412,
     "geom:bbox":"-8.470911,6.58316134812,-7.06773696113,8.15437938757",
     "geom:latitude":7.474026,
     "geom:longitude":-7.82156,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.MN.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833954,
-    "wof:geomhash":"f5fbcda15276656b61780cc98f607781",
+    "wof:geomhash":"305fdd03a3bc1b3c5adc2f27044c6cb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785021,
-    "wof:lastmodified":1566643359,
+    "wof:lastmodified":1695886339,
     "wof:name":"Tonkpi",
     "wof:parent_id":85669867,
     "wof:placetype":"county",

--- a/data/110/878/502/3/1108785023.geojson
+++ b/data/110/878/502/3/1108785023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.241853,
-    "geom:area_square_m":15239714380.344561,
+    "geom:area_square_m":15239713488.351303,
     "geom:bbox":"-7.085781,6.261462,-5.951364,7.806019",
     "geom:latitude":7.035738,
     "geom:longitude":-6.60345,
@@ -201,9 +201,10 @@
         "hasc:id":"CI.SM.HS",
         "wd:id":"Q845709"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833955,
-    "wof:geomhash":"47ea1704029c91c0112f77feabf97ab0",
+    "wof:geomhash":"9614daa7bd7f5dc4ea2de32251b17348",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":1108785023,
-    "wof:lastmodified":1690866717,
+    "wof:lastmodified":1695886340,
     "wof:name":"Haut-Sassa",
     "wof:parent_id":85669883,
     "wof:placetype":"county",

--- a/data/110/878/502/5/1108785025.geojson
+++ b/data/110/878/502/5/1108785025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711409,
-    "geom:area_square_m":8729372935.088001,
+    "geom:area_square_m":8729374391.202923,
     "geom:bbox":"-6.440849,6.500215,-5.400139,7.757166",
     "geom:latitude":7.086047,
     "geom:longitude":-5.892828,
@@ -207,9 +207,10 @@
         "hasc:id":"CI.SM.MH",
         "wd:id":"Q839083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833956,
-    "wof:geomhash":"120561f6e5de97af661c87a734a46c70",
+    "wof:geomhash":"0a340c95f1d6475c584a5fa60109e90d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":1108785025,
-    "wof:lastmodified":1690866717,
+    "wof:lastmodified":1695886340,
     "wof:name":"Marahoue",
     "wof:parent_id":85669877,
     "wof:placetype":"county",

--- a/data/110/878/502/7/1108785027.geojson
+++ b/data/110/878/502/7/1108785027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.841961,
-    "geom:area_square_m":10256923723.08374,
+    "geom:area_square_m":10256924730.940903,
     "geom:bbox":"-6.967208,9.060188,-6.022167,10.740015",
     "geom:latitude":9.861052,
     "geom:longitude":-6.469567,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.SV.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833957,
-    "wof:geomhash":"afe8956f9dc7378553fd1af337563e58",
+    "wof:geomhash":"9ddad9c246dcb496cbd34cd8f75049f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785027,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886486,
     "wof:name":"Bagoue",
     "wof:parent_id":85669855,
     "wof:placetype":"county",

--- a/data/110/878/502/9/1108785029.geojson
+++ b/data/110/878/502/9/1108785029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.032089,
-    "geom:area_square_m":12589733743.664551,
+    "geom:area_square_m":12589733743.664642,
     "geom:bbox":"-6.3170410733,8.53884361282,-5.29651984579,10.4171709521",
     "geom:latitude":9.415211,
     "geom:longitude":-5.832391,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"CI.SV.PR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833958,
-    "wof:geomhash":"f9847fb5e52d83f81950af965269733d",
+    "wof:geomhash":"f08de2e990a9f4ab00780f439a66c998",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108785029,
-    "wof:lastmodified":1566643359,
+    "wof:lastmodified":1695886339,
     "wof:name":"Poro",
     "wof:parent_id":85669855,
     "wof:placetype":"county",

--- a/data/110/878/503/5/1108785035.geojson
+++ b/data/110/878/503/5/1108785035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.429927,
-    "geom:area_square_m":17438020240.554146,
+    "geom:area_square_m":17438020240.554279,
     "geom:bbox":"-5.82586542153,8.63287044446,-3.79572490297,10.468109",
     "geom:latitude":9.505243,
     "geom:longitude":-4.820166,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.SV.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833959,
-    "wof:geomhash":"95cadf6beccca17d0d68974830575555",
+    "wof:geomhash":"189036e27b80c2fecbc7738c3a6fa57f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785035,
-    "wof:lastmodified":1566643362,
+    "wof:lastmodified":1695886340,
     "wof:name":"Tchologo",
     "wof:parent_id":85669855,
     "wof:placetype":"county",

--- a/data/110/878/503/9/1108785039.geojson
+++ b/data/110/878/503/9/1108785039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.736014,
-    "geom:area_square_m":9018770560.576273,
+    "geom:area_square_m":9018771498.503801,
     "geom:bbox":"-5.771806,7.228729,-4.495125,8.136002",
     "geom:latitude":7.703385,
     "geom:longitude":-5.216101,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"CI.VB.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833960,
-    "wof:geomhash":"3fd36c17eaf21d34d57c05861fdb0be9",
+    "wof:geomhash":"d75bcb52b712c3eca512fe15fb40b86b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108785039,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886487,
     "wof:name":"Gbeke",
     "wof:parent_id":85669899,
     "wof:placetype":"county",

--- a/data/110/878/504/1/1108785041.geojson
+++ b/data/110/878/504/1/1108785041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.582263,
-    "geom:area_square_m":19348707618.73666,
+    "geom:area_square_m":19348708287.203579,
     "geom:bbox":"-5.727541,7.817059,-3.901561,9.423622",
     "geom:latitude":8.520167,
     "geom:longitude":-4.838495,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.VB.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833961,
-    "wof:geomhash":"eae127128cede9e26388ac8522534a79",
+    "wof:geomhash":"d78295a749254cc03c0667639d39716d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785041,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886487,
     "wof:name":"Hambol",
     "wof:parent_id":85669899,
     "wof:placetype":"county",

--- a/data/110/878/504/3/1108785043.geojson
+++ b/data/110/878/504/3/1108785043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.719876,
-    "geom:area_square_m":8806010391.428959,
+    "geom:area_square_m":8806009927.461798,
     "geom:bbox":"-8.243753,7.840886,-7.068122,9.074688",
     "geom:latitude":8.391477,
     "geom:longitude":-7.627897,
@@ -219,9 +219,10 @@
         "hasc:id":"CI.WB.BF",
         "wd:id":"Q799800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833964,
-    "wof:geomhash":"dac1fd2a755d6595f657f99082d9a4ae",
+    "wof:geomhash":"74faf8ac0dfcf924168ed2fa07426918",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":1108785043,
-    "wof:lastmodified":1690866718,
+    "wof:lastmodified":1695886619,
     "wof:name":"Bafing",
     "wof:parent_id":85669863,
     "wof:placetype":"county",

--- a/data/110/878/504/5/1108785045.geojson
+++ b/data/110/878/504/5/1108785045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.89464,
-    "geom:area_square_m":10944466254.258715,
+    "geom:area_square_m":10944466254.258553,
     "geom:bbox":"-6.70925135411,7.54203436992,-5.33957042156,9.21187676451",
     "geom:latitude":8.365465,
     "geom:longitude":-6.040461,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.WB.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833965,
-    "wof:geomhash":"427e9c47e50155f2c6b4ecea748df163",
+    "wof:geomhash":"e437e052734f7ec475ccac277769c3e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785045,
-    "wof:lastmodified":1566643362,
+    "wof:lastmodified":1695886341,
     "wof:name":"Bere",
     "wof:parent_id":85669871,
     "wof:placetype":"county",

--- a/data/110/878/504/7/1108785047.geojson
+++ b/data/110/878/504/7/1108785047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.939297,
-    "geom:area_square_m":11490354433.893587,
+    "geom:area_square_m":11490354442.110477,
     "geom:bbox":"-7.228719,7.736006,-6.241731,9.118998",
     "geom:latitude":8.38026,
     "geom:longitude":-6.757545,
@@ -210,9 +210,10 @@
         "hasc:id":"CI.WB.WR",
         "wd:id":"Q846056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833966,
-    "wof:geomhash":"3d58b24a3193df0a5ac2d35640e8f8e2",
+    "wof:geomhash":"375d99d4f1b6a71e55dc8a8e39b9a2dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":1108785047,
-    "wof:lastmodified":1690866717,
+    "wof:lastmodified":1695886619,
     "wof:name":"Worodougou",
     "wof:parent_id":85669871,
     "wof:placetype":"county",

--- a/data/110/878/504/9/1108785049.geojson
+++ b/data/110/878/504/9/1108785049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.811875,
-    "geom:area_square_m":22117528942.24028,
+    "geom:area_square_m":22117528682.864414,
     "geom:bbox":"-4.30948,8.19808,-2.597116,9.954446",
     "geom:latitude":9.165571,
     "geom:longitude":-3.445303,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.ZA.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833967,
-    "wof:geomhash":"5e19254db44e65cc677347caa2689755",
+    "wof:geomhash":"c06e5a5805782e93cccf2c480853501f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785049,
-    "wof:lastmodified":1627522002,
+    "wof:lastmodified":1695886487,
     "wof:name":"Bounkani",
     "wof:parent_id":85669895,
     "wof:placetype":"county",

--- a/data/110/878/505/3/1108785053.geojson
+++ b/data/110/878/505/3/1108785053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.326463,
-    "geom:area_square_m":16242336556.236118,
+    "geom:area_square_m":16242336556.236139,
     "geom:bbox":"-4.06165216723,7.05593273508,-2.493031,8.78954687047",
     "geom:latitude":7.992085,
     "geom:longitude":-3.210541,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"CI.ZA.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1481833968,
-    "wof:geomhash":"1405cf4c589d613a47bc1a044ee02782",
+    "wof:geomhash":"4d9235560a171dec3bf4830051da5a2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108785053,
-    "wof:lastmodified":1566643360,
+    "wof:lastmodified":1695886340,
     "wof:name":"Gontougo",
     "wof:parent_id":85669895,
     "wof:placetype":"county",

--- a/data/110/880/610/1/1108806101.geojson
+++ b/data/110/880/610/1/1108806101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.507352,
-    "geom:area_square_m":30774462730.342613,
+    "geom:area_square_m":30774459843.627434,
     "geom:bbox":"-8.602059,5.618337,-6.973582,8.154379",
     "geom:latitude":6.949693,
     "geom:longitude":-7.653853,
@@ -152,11 +152,13 @@
         "gn:id":2597323,
         "gp:id":55966994,
         "hasc:id":"CI.MN",
+        "iso:code":"CI-MG",
         "iso:id":"CI-MG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990515,
-    "wof:geomhash":"599a4ff3eab2d77951087460435efe4e",
+    "wof:geomhash":"aafd78ad4fde190e099d255aa7da748e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +173,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893668,
+    "wof:lastmodified":1695884502,
     "wof:name":"Montagnes",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/610/3/1108806103.geojson
+++ b/data/110/880/610/3/1108806103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.280704,
-    "geom:area_square_m":15750314281.297451,
+    "geom:area_square_m":15750313784.862795,
     "geom:bbox":"-6.416361,5.161333,-4.93715,6.649997",
     "geom:latitude":5.959446,
     "geom:longitude":-5.612924,
@@ -23,7 +23,7 @@
     "lbl:longitude":-5.663275,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:bel_x_preferred":[
@@ -128,11 +128,13 @@
     "wof:concordances":{
         "fips:code":"IV95",
         "hasc:id":"CI.GD",
+        "iso:code":"CI-GD",
         "iso:id":"CI-GD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990516,
-    "wof:geomhash":"bc38516ad3d29826cd7e169dad6da79d",
+    "wof:geomhash":"67eda3440119681005baf3f39d79a650",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +149,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893668,
+    "wof:lastmodified":1695884282,
     "wof:name":"Goh-Djiboua",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/610/5/1108806105.geojson
+++ b/data/110/880/610/5/1108806105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.682117,
-    "geom:area_square_m":20691623221.33989,
+    "geom:area_square_m":20691623886.292755,
     "geom:bbox":"-5.50802,5.091222,-3.301239,6.643886",
     "geom:latitude":5.83276,
     "geom:longitude":-4.271129,
@@ -23,7 +23,7 @@
     "lbl:longitude":-3.920975,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:bel_x_preferred":[
@@ -107,11 +107,13 @@
     "wof:concordances":{
         "fips:code":"IV82",
         "hasc:id":"CI.LN",
+        "iso:code":"CI-LG",
         "iso:id":"CI-LG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990517,
-    "wof:geomhash":"f7d50bc562cc925a8cc3f594bcca1bef",
+    "wof:geomhash":"ddae1f3fed42efdf655d9945df4249a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +128,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636494803,
+    "wof:lastmodified":1695884285,
     "wof:name":"Lagunes",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/610/7/1108806107.geojson
+++ b/data/110/880/610/7/1108806107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.132702,
-    "geom:area_square_m":26171344671.450089,
+    "geom:area_square_m":26171343791.390839,
     "geom:bbox":"-5.676235,6.188029,-3.496186,8.046169",
     "geom:latitude":7.047097,
     "geom:longitude":-4.444967,
@@ -68,11 +68,13 @@
     "wof:concordances":{
         "fips:code":"IV81",
         "hasc:id":"CI.LA",
+        "iso:code":"CI-LC",
         "iso:id":"CI-LC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990517,
-    "wof:geomhash":"445e39171d85b3f130f41b92719c5608",
+    "wof:geomhash":"538d09e36607c20bb43d2e6f31974da4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +89,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636494803,
+    "wof:lastmodified":1695884776,
     "wof:name":"Lacs",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/610/9/1108806109.geojson
+++ b/data/110/880/610/9/1108806109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.553813,
-    "geom:area_square_m":31240831079.58144,
+    "geom:area_square_m":31240830040.320793,
     "geom:bbox":"-8.243753,7.542034,-5.33957,9.211877",
     "geom:latitude":8.378239,
     "geom:longitude":-6.751677,
@@ -23,7 +23,7 @@
     "lbl:longitude":-6.609087,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:bel_x_preferred":[
@@ -89,11 +89,13 @@
     "wof:concordances":{
         "fips:code":"IV97",
         "hasc:id":"CI.WB",
+        "iso:code":"CI-WR",
         "iso:id":"CI-WR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990518,
-    "wof:geomhash":"dadd938b3cec4e1d9812d5a3e673d679",
+    "wof:geomhash":"45ebe2833162cd9d7d0cf6f12a1b48c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +110,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893667,
+    "wof:lastmodified":1695884282,
     "wof:name":"Woroba",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/611/3/1108806113.geojson
+++ b/data/110/880/611/3/1108806113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.142384,
-    "geom:area_square_m":14044824113.272734,
+    "geom:area_square_m":14044824188.901672,
     "geom:bbox":"-3.85233,5.091188,-2.723532,7.355218",
     "geom:latitude":6.099425,
     "geom:longitude":-3.301381,
@@ -23,7 +23,7 @@
     "lbl:longitude":-3.163475,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:bel_x_preferred":[
@@ -104,11 +104,13 @@
     "wof:concordances":{
         "fips:code":"IV94",
         "hasc:id":"CI.CM",
+        "iso:code":"CI-CM",
         "iso:id":"CI-CM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990518,
-    "wof:geomhash":"8605689ead8c6759eb33f7e96b024100",
+    "wof:geomhash":"94c4b834aca8da15e2d642456881a475",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +125,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636494803,
+    "wof:lastmodified":1695884285,
     "wof:name":"Comoe",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/611/5/1108806115.geojson
+++ b/data/110/880/611/5/1108806115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17471,
-    "geom:area_square_m":2150682559.752305,
+    "geom:area_square_m":2150682559.752309,
     "geom:bbox":"-4.45655303934,5.21850385961,-3.72026855823,5.60399687891",
     "geom:latitude":5.41496,
     "geom:longitude":-4.075835,
@@ -23,7 +23,7 @@
     "lbl:longitude":-4.105459,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:afr_x_preferred":[
@@ -386,11 +386,13 @@
     "wof:concordances":{
         "fips:code":"IV93",
         "hasc:id":"CI.AB",
+        "iso:code":"CI-AB",
         "iso:id":"CI-AB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990518,
-    "wof:geomhash":"8bfe3a831ed29c8968b917e9c43170b6",
+    "wof:geomhash":"5a68c9fe2802fd88e424375804f22c70",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -405,7 +407,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566643358,
+    "wof:lastmodified":1695884281,
     "wof:name":"Abidjan",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/611/7/1108806117.geojson
+++ b/data/110/880/611/7/1108806117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.953262,
-    "geom:area_square_m":23969087315.432571,
+    "geom:area_square_m":23969087879.554226,
     "geom:bbox":"-7.085781,6.261462,-5.400139,7.806019",
     "geom:latitude":7.054062,
     "geom:longitude":-6.34463,
@@ -125,11 +125,13 @@
     "wof:concordances":{
         "fips:code":"IV96",
         "hasc:id":"CI.SM",
+        "iso:code":"CI-SM",
         "iso:id":"CI-SM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990519,
-    "wof:geomhash":"3b3d5a12985a1ba254aab29af74fdcec",
+    "wof:geomhash":"2bb21c3fb4ea8481ba8408c769c49cc2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +146,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893668,
+    "wof:lastmodified":1695884502,
     "wof:name":"Sassandra-Marahoue",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/110/880/611/9/1108806119.geojson
+++ b/data/110/880/611/9/1108806119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169408,
-    "geom:area_square_m":2079781302.129818,
+    "geom:area_square_m":2079781302.129819,
     "geom:bbox":"-5.53114934606,6.55267758602,-4.958782179,7.07975937604",
     "geom:latitude":6.855955,
     "geom:longitude":-5.268561,
@@ -23,7 +23,7 @@
     "lbl:longitude":-5.288044,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:afr_x_preferred":[
@@ -416,11 +416,13 @@
     "wof:concordances":{
         "fips:code":"IV98",
         "hasc:id":"CI.YM",
+        "iso:code":"CI-YM",
         "iso:id":"CI-YM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:created":1485990519,
-    "wof:geomhash":"fbd91cde9b22990946827c0f2e6ea58b",
+    "wof:geomhash":"35a3c13dfc06bddf47e2044744213388",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -435,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566643357,
+    "wof:lastmodified":1695884281,
     "wof:name":"Yamoussoukro",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/421/188/355/421188355.geojson
+++ b/data/421/188/355/421188355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.995729,
-    "geom:area_square_m":12265150549.041803,
+    "geom:area_square_m":12265151202.031313,
     "geom:bbox":"-7.601067,4.352833,-6.299407,5.669999",
     "geom:latitude":5.01231,
     "geom:longitude":-7.043448,
@@ -214,12 +214,13 @@
         "qs_pg:id":22226,
         "wd:id":"Q609831"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CI",
     "wof:created":1459009543,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6d67c5df3ea7e40456ff80c7f671c552",
+    "wof:geomhash":"8cf014ae4f9b052e4a1414abd0777d18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":421188355,
-    "wof:lastmodified":1690866726,
+    "wof:lastmodified":1695886620,
     "wof:name":"San Pedro",
     "wof:parent_id":85669889,
     "wof:placetype":"county",

--- a/data/856/324/49/85632449.geojson
+++ b/data/856/324/49/85632449.geojson
@@ -1289,6 +1289,7 @@
         "gp:id":23424854,
         "hasc:id":"CI",
         "icao:code":"TU",
+        "iso:code":"CI",
         "loc:id":"n82047825",
         "m49:code":"384",
         "mzb:id":"c-te-d-ivoire",
@@ -1298,6 +1299,7 @@
         "wd:id":"Q1008",
         "wk:page":"Ivory Coast"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:country_alpha3":"CIV",
     "wof:geom_alt":[
@@ -1319,7 +1321,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639666,
+    "wof:lastmodified":1695881326,
     "wof:name":"Ivory Coast",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/698/55/85669855.geojson
+++ b/data/856/698/55/85669855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.303977,
-    "geom:area_square_m":40284677707.30262,
+    "geom:area_square_m":40284677599.58699,
     "geom:bbox":"-6.967208,8.538844,-3.795725,10.740015",
     "geom:latitude":9.567791,
     "geom:longitude":-5.556684,
@@ -246,16 +246,18 @@
         "gn:id":2597320,
         "gp:id":55967002,
         "hasc:id":"CI.SV",
+        "iso:code":"CI-SV",
         "iso:id":"CI-SV",
         "qs_pg:id":919939,
         "wd:id":"Q21002161",
         "wk:page":"Savanes District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2e24b1510a59b62f55995949dafbe3d",
+    "wof:geomhash":"6e4e599a6086a0cf376067e4b676de27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -270,7 +272,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690866714,
+    "wof:lastmodified":1695884776,
     "wof:name":"Savanes",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/59/85669859.geojson
+++ b/data/856/698/59/85669859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.719775,
-    "geom:area_square_m":20964535408.185528,
+    "geom:area_square_m":20964534563.075649,
     "geom:bbox":"-8.163814,8.51233,-6.586744,10.46204",
     "geom:latitude":9.639978,
     "geom:longitude":-7.388336,
@@ -220,16 +220,18 @@
         "gn:id":2597328,
         "gp:id":55966993,
         "hasc:id":"CI.DE",
+        "iso:code":"CI-DN",
         "iso:id":"CI-DN",
         "qs_pg:id":1024055,
         "wd:id":"Q729010",
         "wk:page":"Dengu\u00e9l\u00e9 Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9ce21146ef8d3ccc59ff39e867e651e",
+    "wof:geomhash":"fec8c86a9ddf4f27a668bff6027c3e62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +246,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690866713,
+    "wof:lastmodified":1695884331,
     "wof:name":"Denguele",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/89/85669889.geojson
+++ b/data/856/698/89/85669889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.294854,
-    "geom:area_square_m":28251343138.740681,
+    "geom:area_square_m":28251342972.918446,
     "geom:bbox":"-7.601067,4.352833,-5.381298,6.557625",
     "geom:latitude":5.359994,
     "geom:longitude":-6.678604,
@@ -261,16 +261,18 @@
         "gn:id":2597326,
         "gp:id":55967008,
         "hasc:id":"CI.BA",
+        "iso:code":"CI-BS",
         "iso:id":"CI-BS",
         "qs_pg:id":919941,
         "wd:id":"Q809733",
         "wk:page":"Bas-Sassandra Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f99659d81f4b24e21e0fd8edc575d26",
+    "wof:geomhash":"332551ac9b6ac5451fd442938c512ffe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690866713,
+    "wof:lastmodified":1695884775,
     "wof:name":"Bas-Sassandra",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/95/85669895.geojson
+++ b/data/856/698/95/85669895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.138338,
-    "geom:area_square_m":38359865498.476616,
+    "geom:area_square_m":38359866123.535126,
     "geom:bbox":"-4.30948,7.055933,-2.493031,9.954446",
     "geom:latitude":8.66958,
     "geom:longitude":-3.346077,
@@ -218,16 +218,18 @@
         "gn:id":2597325,
         "gp:id":55967007,
         "hasc:id":"CI.ZA",
+        "iso:code":"CI-ZZ",
         "iso:id":"CI-ZZ",
         "qs_pg:id":74108,
         "wd:id":"Q21003689",
         "wk:page":"Zanzan District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"308c33ad7dc738585e1ef5ed89d4a197",
+    "wof:geomhash":"94a7a2ac4bb0cd9b3f93f59e23d87c93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -242,7 +244,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690866712,
+    "wof:lastmodified":1695884776,
     "wof:name":"Zanzan",
     "wof:parent_id":85632449,
     "wof:placetype":"region",

--- a/data/856/698/99/85669899.geojson
+++ b/data/856/698/99/85669899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.318277,
-    "geom:area_square_m":28367478179.312981,
+    "geom:area_square_m":28367479785.707478,
     "geom:bbox":"-5.771806,7.228729,-3.901561,9.423622",
     "geom:latitude":8.260853,
     "geom:longitude":-4.958378,
@@ -285,16 +285,18 @@
         "gn:id":2597321,
         "gp:id":55967005,
         "hasc:id":"CI.VB",
+        "iso:code":"CI-VB",
         "iso:id":"CI-VB",
         "qs_pg:id":393662,
         "wd:id":"Q21002356",
         "wk:page":"Vall\u00e9e du Bandama District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66beaa13a85ca807a692de980f979e80",
+    "wof:geomhash":"3829d6fa3b94b81ae8101c33d49e1276",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690866714,
+    "wof:lastmodified":1695884331,
     "wof:name":"Valle Du Bandama",
     "wof:parent_id":85632449,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.